### PR TITLE
feat: update to use it as a lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -412,6 +412,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.9",
+ "quote 1.0.2",
+ "strsim 0.9.3",
+ "syn 1.0.16",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote 1.0.2",
+ "syn 1.0.16",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2 1.0.9",
+ "quote 1.0.2",
+ "syn 1.0.16",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.9",
+ "quote 1.0.2",
+ "syn 1.0.16",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +589,7 @@ version = "2.0.0-beta.1"
 dependencies = [
  "assert_cmd",
  "console",
+ "derive_builder",
  "dialoguer",
  "difference",
  "directories",
@@ -935,6 +996,12 @@ dependencies = [
  "tokio",
  "tokio-tls",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2127,6 +2194,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 
 [dependencies]
 console = "0.10.0"
+derive_builder = "0.9.0"
 dialoguer = "0.5.0"
 difference = "2.0.0"
 directories = "2.0.2"

--- a/src/cli_opt.rs
+++ b/src/cli_opt.rs
@@ -38,7 +38,10 @@ pub enum Command {
     Inspect,
 }
 
-#[derive(StructOpt, Debug, Default, Clone)]
+#[derive(StructOpt, Debug, Default, Clone, Builder)]
+#[builder(default)]
+#[builder(field(private))]
+#[builder(setter(into, strip_option))]
 pub struct ApplyOpts {
     /// ask for plan confirmation
     #[structopt(long, default_value = "Never", possible_values = &AskConfirmation::variants(), case_insensitive = true)]
@@ -67,6 +70,10 @@ pub struct ApplyOpts {
         //default_value = "."
     )]
     pub dst_folder: PathBuf,
+}
+
+impl ApplyOpts {
+    pub fn builder() -> ApplyOptsBuilder { ApplyOptsBuilder::default() }
 }
 
 arg_enum! {

--- a/src/cli_opt.rs
+++ b/src/cli_opt.rs
@@ -73,7 +73,9 @@ pub struct ApplyOpts {
 }
 
 impl ApplyOpts {
-    pub fn builder() -> ApplyOptsBuilder { ApplyOptsBuilder::default() }
+    pub fn builder() -> ApplyOptsBuilder {
+        ApplyOptsBuilder::default()
+    }
 }
 
 arg_enum! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ pub struct Ctx {
 }
 
 impl Ctx {
-    pub fn builder() -> CtxBuilder {CtxBuilder::default()}
+    pub fn builder() -> CtxBuilder {
+        CtxBuilder::default()
+    }
 }
 
 impl Default for Ctx {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate serde;
+#[macro_use]
+extern crate derive_builder;
 
 mod cli_opt;
 mod error;
@@ -22,6 +24,7 @@ mod variables;
 pub use crate::cli_opt::*;
 pub use crate::error::*;
 pub use crate::source_loc::SourceLoc;
+pub use crate::source_uri::SourceUri;
 
 use crate::files::ChildPath;
 use crate::source_file::{SourceFile, SourceFileMetadata};
@@ -34,10 +37,17 @@ use snafu::ResultExt;
 use std::fs;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
+#[builder(default)]
+#[builder(field(private))]
+#[builder(setter(into, strip_option))]
 pub struct Ctx {
     pub logger: slog::Logger,
     pub cmd_opt: ApplyOpts,
+}
+
+impl Ctx {
+    pub fn builder() -> CtxBuilder {CtxBuilder::default()}
 }
 
 impl Default for Ctx {

--- a/src/source_loc.rs
+++ b/src/source_loc.rs
@@ -10,8 +10,11 @@ use std::fs;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-#[derive(StructOpt, Debug, Default, Clone, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(StructOpt, Debug, Default, Clone, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Builder)]
 #[serde(deny_unknown_fields, default)]
+#[builder(default)]
+#[builder(field(private))]
+#[builder(setter(into, strip_option))]
 pub struct SourceLoc {
     /// uri / path of the template
     #[structopt(short = "s", long = "source")]
@@ -27,6 +30,8 @@ pub struct SourceLoc {
 }
 
 impl SourceLoc {
+    pub fn builder() -> SourceLocBuilder { SourceLocBuilder::default() }
+
     pub fn find_remote_cache_folder() -> Result<PathBuf> {
         let app_name = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "".into());
         let project_dirs = directories::ProjectDirs::from("", &app_name, &app_name)

--- a/src/source_loc.rs
+++ b/src/source_loc.rs
@@ -10,7 +10,9 @@ use std::fs;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-#[derive(StructOpt, Debug, Default, Clone, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Builder)]
+#[derive(
+    StructOpt, Debug, Default, Clone, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Builder,
+)]
 #[serde(deny_unknown_fields, default)]
 #[builder(default)]
 #[builder(field(private))]
@@ -30,7 +32,9 @@ pub struct SourceLoc {
 }
 
 impl SourceLoc {
-    pub fn builder() -> SourceLocBuilder { SourceLocBuilder::default() }
+    pub fn builder() -> SourceLocBuilder {
+        SourceLocBuilder::default()
+    }
 
     pub fn find_remote_cache_folder() -> Result<PathBuf> {
         let app_name = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "".into());


### PR DESCRIPTION
Some changes to be able to use ffizer as a lib.
The id is to be able to write something like:
```rust
let source = SourceLoc::builder()
        .uri(SourceUri::from_str(src.as_ref())?)
        .rev(rev.as_ref())
        .build()
        .unwrap();

    let apply_opts = ApplyOpts::builder()
        .src(source)
        .dst_folder(dst.as_ref())
        .build()
        .unwrap();

    let ctx = Ctx::builder().cmd_opt(apply_opts).build().unwrap();

    ffizer::process(&ctx)?;
```

But this is just a quick hack.  
I like the way ffizer work as a binary, but I don' t think it has been designed to be a lib.  
Two main problems in my opinion :
* The `Ctx` thing, closely tied to the binarry part implies to recreate a context before using the lib.
    - strange to dummy init logs
    - useful methods should be easily called (I'd like to have an `apply` method !) 
* Log system : slog doesn't work well with the standard log crate. So if the project using the lib does not use slog... no logs !