### PR TITLE
 export SourceUri in order to use ffizer as library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod variables;
 pub use crate::cfg::provide_json_schema;
 pub use crate::cli_opt::*;
 pub use crate::source_loc::SourceLoc;
+pub use crate::source_uri::SourceUri;
 
 use crate::cfg::{render_composite, TemplateComposite};
 use crate::error::*;


### PR DESCRIPTION
I would like to be able, to use ffizer in a library like this: 
```rust 
    let mut ctx = Ctx::default();
    ctx.cmd_opt.dst_folder = PathBuf::from("/my/destination/path");
    ctx.cmd_opt.src.uri = SourceUri::from_str("/my/source/path").unwrap();
    ctx.cmd_opt.update_mode = UpdateMode::Override;
    ffizer::process(&ctx).unwrap();
```

SourceUri, however, is currently not exported.

This pull request fixes that.