### PR TITLE
chore: release v2.13.5

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -39,18 +39,18 @@ jobs:
               # use-cross: true,
               jreleaser_platform: linux-aarch_64,
             }
-          - {
-              target: x86_64-unknown-linux-musl,
-              os: ubuntu-latest,
-              use-cross: true,
-              jreleaser_platform: linux_musl-x86_64,
-            }
-          - {
-              target: aarch64-unknown-linux-musl,
-              os: ubuntu-24.04-arm,
-              use-cross: true,
-              jreleaser_platform: linux_musl-aarch_64,
-            }
+          # - {
+          #     target: x86_64-unknown-linux-musl,
+          #     os: ubuntu-latest,
+          #     use-cross: true,
+          #     jreleaser_platform: linux_musl-x86_64,
+          #   }
+          # - {
+          #     target: aarch64-unknown-linux-musl,
+          #     os: ubuntu-24.04-arm,
+          #     use-cross: true,
+          #     jreleaser_platform: linux_musl-aarch_64,
+          #   }
     runs-on: ${{ matrix.job.os }}
     steps:
       - name: Checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ffizer"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffizer"
-version = "2.13.4"
+version = "2.13.5"
 authors = ["David Bernard"]
 description = """ffizer is a files and folders initializer / generator.
 It creates or updates any kind (or part) of project from template(s)"""

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -11,8 +11,8 @@ project:
   links:
     homepage: https://ffizer.github.io/ffizer/book/
     bugTracker: https://github.com/ffizer/ffizer/issues
-    donation:
-  inceptionYear: 2018
+    donation: https://github.com/sponsors/davidB
+  inceptionYear: "2018"
   stereotype: CLI
 
 platform:
@@ -23,8 +23,8 @@ platform:
     "linux-x86_64": "x86_64-unknown-linux-gnu"
     "linux-aarch_64": "aarch64-unknown-linux-gnu"
     "windows-x86_64": "x86_64-pc-windows-msvc"
-    "linux_musl-x86_64": "x86_64-unknown-linux-musl"
-    "linux_musl-aarch_64": "aarch64-unknown-linux-musl"
+    # "linux_musl-x86_64": "x86_64-unknown-linux-musl"
+    # "linux_musl-aarch_64": "aarch64-unknown-linux-musl"
 
 release:
   github:
@@ -92,10 +92,10 @@ distributions:
         platform: "linux-aarch_64"
       - path: "{{artifactsDir}}/{{distributionName}}_{{projectVersion}}-aarch64-unknown-linux-gnu.zip"
         platform: "linux-aarch_64"
-      - path: "{{artifactsDir}}/{{distributionName}}_{{projectVersion}}-x86_64-unknown-linux-musl.tgz"
-        platform: "linux_musl-x86_64"
-      - path: "{{artifactsDir}}/{{distributionName}}_{{projectVersion}}-aarch64-unknown-linux-musl.tgz"
-        platform: "linux_musl-aarch_64"
+      # - path: "{{artifactsDir}}/{{distributionName}}_{{projectVersion}}-x86_64-unknown-linux-musl.tgz"
+      #   platform: "linux_musl-x86_64"
+      # - path: "{{artifactsDir}}/{{distributionName}}_{{projectVersion}}-aarch64-unknown-linux-musl.tgz"
+      #   platform: "linux_musl-aarch_64"
 
 packagers:
   asdf:


### PR DESCRIPTION



## 🤖 New release

* `ffizer`: 2.13.4 -> 2.13.5

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).