### PR TITLE
fix: correct homebrew package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Or download the binary for your platform from [github releases](https://github.c
 #### via homebrew (MacOs & Linux)
 
 ```sh
-brew install ffizer/ffizer/ffizer-bin
+brew install ffizer/ffizer/ffizer
 ffizer upgrade
 ```
 


### PR DESCRIPTION
Current package name is not working:

```shell
❯ brew install ffizer/ffizer/ffizer-bin
Warning: No available formula or cask with the name "ffizer/ffizer/ffizer-bin". Did you mean ffizer/ffizer/ffizer?
```

but if we remove `-bin` it works:

```shell
❯ brew install ffizer/ffizer/ffizer
==> Fetching downloads for: ffizer
==> Fetching ffizer/ffizer/ffizer
==> Downloading https://github.com/ffizer/ffizer/releases/download/2.13.5/ffizer_2.13.5-aarch64-apple-darwin.zip
==> Downloading from https://release-assets.githubusercontent.com/github-production-release-asset/156519817/eed812c1-edc7-45eb-9
######################################################################################################################### 100.0%
==> Installing ffizer from ffizer/ffizer
🍺  /opt/homebrew/Cellar/ffizer/2.13.5: 5 files, 8.0MB, built in 1 second
```