### PR TITLE
chore: release v2.13.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ffizer"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffizer"
-version = "2.13.7"
+version = "2.13.8"
 description = """ffizer is a files and folders initializer / generator.
 It creates or updates any kind (or part) of project from template(s)"""
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `ffizer`: 2.13.7 -> 2.13.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.13.7](https://github.com/ffizer/ffizer/compare/2.13.6...2.13.7) - 2026-02-09

### <!-- 1 -->Fixed

- *(deps)* update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).