### PR TITLE
chore: release v2.13.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
             # target_platform: x86_64-apple-darwin
           - runner: "macOS-latest"
             # target_platform: aarch64-apple-darwin
+          - runner: "windows-latest"
+            # target_platform: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v6
       - uses: mozilla-actions/sccache-action@v0.0.9

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ffizer"
-version = "2.13.8"
+version = "2.13.9"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffizer"
-version = "2.13.8"
+version = "2.13.9"
 description = """ffizer is a files and folders initializer / generator.
 It creates or updates any kind (or part) of project from template(s)"""
 readme = "README.md"

--- a/tests/data/template_1/.ffizer.samples.d/my-project.expected/dir_3/my_project_bug264.txt
+++ b/tests/data/template_1/.ffizer.samples.d/my-project.expected/dir_3/my_project_bug264.txt
@@ -1,0 +1,2 @@
+
+I'm my_project_bug264.txt .

--- a/tests/data/template_1/dir_3/{{ package_name }}_bug264.txt
+++ b/tests/data/template_1/dir_3/{{ package_name }}_bug264.txt
@@ -1,0 +1,2 @@
+
+I'm my_project_bug264.txt .


### PR DESCRIPTION



## 🤖 New release

* `ffizer`: 2.13.8 -> 2.13.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.13.7](https://github.com/ffizer/ffizer/compare/2.13.6...2.13.7) - 2026-02-09

### <!-- 1 -->Fixed

- *(deps)* update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).