### PR TITLE
chore: release v2.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <a name="x.y.z-dev" data-comment="this line is used by gitmoji-changelog, don't remove it!"></a>
 
+## [2.13.9](https://github.com/ffizer/ffizer/compare/2.13.8...2.13.9) - 2026-04-07
+
+### <!-- 1 -->Fixed
+
+- hack to handle windows path with `folder\{{variable}}...'
+
 ## [2.13.7](https://github.com/ffizer/ffizer/compare/2.13.6...2.13.7) - 2026-02-09
 
 ### <!-- 1 -->Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ffizer"
-version = "2.13.8"
+version = "2.13.9"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffizer"
-version = "2.13.8"
+version = "2.13.9"
 description = """ffizer is a files and folders initializer / generator.
 It creates or updates any kind (or part) of project from template(s)"""
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `ffizer`: 2.13.8 -> 2.13.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.13.9](https://github.com/ffizer/ffizer/compare/2.13.8...2.13.9) - 2026-04-07

### <!-- 1 -->Fixed

- hack to handle windows path with `folder\{{variable}}...'
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).